### PR TITLE
Add support for Fahrenheit/Celcius based on device setting.

### DIFF
--- a/custom_components/alpicool_ble/climate.py
+++ b/custom_components/alpicool_ble/climate.py
@@ -47,10 +47,7 @@ class AlpicoolClimateZone(AlpicoolEntity, ClimateEntity):
     """Representation of an Alpicool refrigerator zone."""
 
     _attr_hvac_modes = [HVACMode.COOL, HVACMode.OFF]
-    _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 1.0
-    _attr_min_temp = -20
-    _attr_max_temp = 20
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
     )
@@ -69,6 +66,32 @@ class AlpicoolClimateZone(AlpicoolEntity, ClimateEntity):
     def _is_dual_zone(self) -> bool:
         """Helper to check if this is a dual-zone model."""
         return "right_current" in self.api.status
+
+    @property
+    def _is_fahrenheit(self) -> bool:
+        """Check if the device is set to Fahrenheit (unit=1)."""
+        return self.api.status.get("unit", 0) == 1
+
+    @property
+    def temperature_unit(self) -> str:
+        """Return the unit of measurement based on device setting."""
+        if self._is_fahrenheit:
+            return UnitOfTemperature.FAHRENHEIT
+        return UnitOfTemperature.CELSIUS
+
+    @property
+    def min_temp(self) -> float:
+        """Return the minimum temperature based on device unit."""
+        if self._is_fahrenheit:
+            return -4  # -20°C = -4°F
+        return -20
+
+    @property
+    def max_temp(self) -> float:
+        """Return the maximum temperature based on device unit."""
+        if self._is_fahrenheit:
+            return 68  # 20°C = 68°F
+        return 20
 
     @property
     def preset_modes(self) -> list[str] | None:


### PR DESCRIPTION
This PR adds support for both Celclus and Fahrenheit temperatures.

**Changes Made**
Removed hardcoded Celsius settings (lines 50, 52-53 in original):

Removed `_attr_temperature_unit = UnitOfTemperature.CELSIUS`
Removed `_attr_min_temp = -20`
Removed `__attr_max_temp = 20_`

Added dynamic properties that read the device's unit setting:
`_is_fahrenheit` - Checks if unit field from device equals 1 (Fahrenheit)

`temperature_unit` - Returns FAHRENHEIT or CELSIUS based on device setting

`min_temp` / `max_temp` - Returns appropriate ranges:

Celsius: -20°C to 20°C
Fahrenheit: -4°F to 68°F

**How It Works**
The Alpicool device sends a unit byte (at position 9 in the BLE payload) indicating whether it's set to Celsius (0) or Fahrenheit (1). The modified code now:
- Reads this setting from self.api.status.get("unit")
- Reports the correct temperature unit to Home Assistant
- Sets appropriate min/max temperature ranges

Tested and working with Alpicool C50 (WT-0001)

<img width="689" height="828" alt="Screenshot 2026-01-30 at 9 23 05 PM" src="https://github.com/user-attachments/assets/4d9c273e-b788-44a9-8aaf-5a275cf8faed" />
